### PR TITLE
Add sleep to the startServer() method

### DIFF
--- a/src/Codeception/Extension/PhpBuiltinServer.php
+++ b/src/Codeception/Extension/PhpBuiltinServer.php
@@ -91,6 +91,8 @@ class PhpBuiltinServer extends Extension
             proc_close($this->resource);
             throw new ExtensionException($this, 'Failed to start server.');
         }
+
+        sleep(1);
     }
 
     private function stopServer()


### PR DESCRIPTION
Im not sure this is the best solution for this but I had some issue where codeception was trying to run test before the server had actually started. Pausing within the startServer method for a period of time (currently 1 second) fixes this.
