### PR TITLE
check HTTP headers presence

### DIFF
--- a/src/Codeception/Extension/Router.php
+++ b/src/Codeception/Extension/Router.php
@@ -25,8 +25,8 @@ class Router
                 $_SERVER['REQUEST_METHOD'],
                 $_SERVER['REQUEST_URI'],
                 $_SERVER['SERVER_PROTOCOL'],
-                $_SERVER['HTTP_REFERER'],
-                $_SERVER['HTTP_USER_AGENT']
+                isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '-',
+                isset($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : '-'
             );
             file_put_contents($accessLog, $logEntry, FILE_APPEND);
         }


### PR DESCRIPTION
`HTTP_REFERER` and `HTTP_USER_AGENT` are optional headers from client.
This fix such notices like:

```
Notice: Undefined index: HTTP_REFERER in /var/www/test/vendor/codeception/phpbuiltinserver/src/Codeception/Extension/Router.php on line 28
Notice: Undefined index: HTTP_USER_AGENT in /var/www/test/vendor/codeception/phpbuiltinserver/src/Codeception/Extension/Router.php on line 29
```
