### PR TITLE
Added quotes to router path in getCommand

### DIFF
--- a/src/Codeception/Extension/PhpBuiltinServer.php
+++ b/src/Codeception/Extension/PhpBuiltinServer.php
@@ -68,7 +68,7 @@ class PhpBuiltinServer extends Extension
         $parameters .= ' -dcodecept.access_log="' . Configuration::logDir() . 'phpbuiltinserver.access_log.txt' . '"';
 
         $command = sprintf(
-            PHP_BINARY . ' %s -S %s:%s -t "%s" %s',
+            PHP_BINARY . ' %s -S %s:%s -t "%s" "%s"',
             $parameters,
             $this->config['hostname'],
             $this->config['port'],


### PR DESCRIPTION
This ensures that the router is properly found when the path includes
spaces.
