### PR TITLE
Option to disable directory index routing

### DIFF
--- a/src/Codeception/Extension/PhpBuiltinServer.php
+++ b/src/Codeception/Extension/PhpBuiltinServer.php
@@ -49,7 +49,7 @@ class PhpBuiltinServer extends Extension
     {
         $this->stopServer();
     }
-    
+
     /**
      * this will prevent cloning
      */
@@ -67,7 +67,11 @@ class PhpBuiltinServer extends Extension
             $parameters .= ' -dcodecept.user_router="' . $this->config['router'] . '"';
         }
         if (isset($this->config['directoryIndex'])) {
-            $parameters .= ' -dcodecept.directory_index="' . $this->config['directoryIndex'] . '"';
+            if ($this->config['directoryIndex'] == false ) {
+                $parameters .= ' -dcodecept.directory_index="noDirectoryIndex"';
+            } else {
+                $parameters .= ' -dcodecept.directory_index="' . $this->config['directoryIndex'] . '"';
+            }
         }
         if (isset($this->config['phpIni'])) {
             $parameters .= ' --php-ini "' . $this->config['phpIni'] . '"';

--- a/src/Codeception/Extension/Router.php
+++ b/src/Codeception/Extension/Router.php
@@ -36,7 +36,7 @@ class Router
         } elseif ($userRouter) {
             return include $userRouter;
         } else {
-            if (is_dir($filePath) && file_exists($filePath . '/' . $directoryIndex)) {
+            if ($directoryIndex !== "noDirectoryIndex" && is_dir($filePath) && file_exists($filePath . '/' . $directoryIndex)) {
                 return include $filePath . '/' . $directoryIndex;
             } else {
                 return false; // serve the requested resource as-is.


### PR DESCRIPTION
In some frameworks, passing index.php, or the directory index back from the router would cause "/" to fail to load a page since it's passing back the output of the directory index.

Some frameworks, like Zend Framework 1 don't behave properly when index.php is passed back.

This adds `false` detection to `directoryIndex` configuration parameter. The values passed to the router is `noDirectoryIndex` since `off` was getting converted to an empty string.
