### PR TITLE
Fix composer.lock warning => composer update --lock

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "96e85e0727405fe7f753abd0ae647d8e",
+    "hash": "7aa25819191d61f9ad24444b40cceeef",
     "packages": [
         {
             "name": "codeception/codeception",
@@ -1265,21 +1265,13 @@
             "time": "2014-07-09 09:05:48"
         }
     ],
-    "packages-dev": [
-
-    ],
-    "aliases": [
-
-    ],
+    "packages-dev": [],
+    "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [
-
-    ],
+    "stability-flags": [],
     "prefer-stable": false,
     "platform": {
         "php": ">=5.4.0"
     },
-    "platform-dev": [
-
-    ]
+    "platform-dev": []
 }


### PR DESCRIPTION
The composer lock was out of date. This fixes the issue:

```
» composer install
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
Warning: The lock file is not up to date with the latest changes in composer.json. You may be getting outdated dependencies. Run update to update them.

  - Installing symfony/yaml (v2.5.2)
    Downloading: 100%         

  - Installing symfony/finder (v2.5.2)
...
```