### PR TITLE
Killing child processes

### DIFF
--- a/src/Codeception/Extension/PhpBuiltinServer.php
+++ b/src/Codeception/Extension/PhpBuiltinServer.php
@@ -123,6 +123,15 @@ class PhpBuiltinServer extends Extension
                     fclose($pipe);
                 }
             }
+            //Getting rid of child processes per http://php.net/manual/en/function.proc-terminate.php#81353 and PHP bug 39992
+            $status = proc_get_status($this->resource);
+			$ppid = $status['pid'];
+			$pids = preg_split('/\s+/', `ps -o pid --no-heading --ppid $ppid`);
+			foreach($pids as $pid) {
+				if(is_numeric($pid)) {
+					posix_kill($pid, 9); //9 is the SIGKILL signal
+				}
+			}
             proc_terminate($this->resource, 2);
             unset($this->resource);
         }


### PR DESCRIPTION
On some systems PHP will spawn child processes, but these are not closed by proc_terminate due to a 8 year old bug in PHP (https://bugs.php.net/bug.php?id=39992)
