### PR TITLE
Use exec when running on platforms with POSIX (non-Windows) process handling

### DIFF
--- a/src/Codeception/Extension/PhpBuiltinServer.php
+++ b/src/Codeception/Extension/PhpBuiltinServer.php
@@ -80,8 +80,17 @@ class PhpBuiltinServer extends Extension
         }
         $parameters .= ' -dcodecept.access_log="' . Configuration::logDir() . 'phpbuiltinserver.access_log.txt' . '"';
 
+        if (function_exists('pcntl_fork')) {
+            // Platform uses POSIX process handling. Use exec to avoid
+            // controlling the shell process instead of the PHP
+            // interpreter.
+            $exec = 'exec ';
+        } else {
+            $exec = '';
+        }
+
         $command = sprintf(
-            PHP_BINARY . ' %s -S %s:%s -t "%s" "%s"',
+            $exec . PHP_BINARY . ' %s -S %s:%s -t "%s" "%s"',
             $parameters,
             $this->config['hostname'],
             $this->config['port'],

--- a/src/Codeception/Extension/PhpBuiltinServer.php
+++ b/src/Codeception/Extension/PhpBuiltinServer.php
@@ -80,7 +80,7 @@ class PhpBuiltinServer extends Extension
         }
         $parameters .= ' -dcodecept.access_log="' . Configuration::logDir() . 'phpbuiltinserver.access_log.txt' . '"';
 
-        if (function_exists('pcntl_fork')) {
+        if (PHP_OS !== 'WINNT' && PHP_OS !== 'WIN32') {
             // Platform uses POSIX process handling. Use exec to avoid
             // controlling the shell process instead of the PHP
             // interpreter.


### PR DESCRIPTION
Avoids the issue where the PHP server process is not terminated
because we control the shell process instead of the interpreter
process. Fixes #17, #4.