### PR TITLE
Added option to force usage of router file

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,7 @@ extensions:
             startDelay: 1
             phpIni: /etc/php5/apache2/php.ini
 ```
+### additional configuration options:
+Option Name | Value | Description
+--- | --- | ---
+alwaysUseRouter | boolean (default: false) | If enabled, all requests will use the specified router file regardless of if the file requested exists in the documentRoot

--- a/src/Codeception/Extension/PhpBuiltinServer.php
+++ b/src/Codeception/Extension/PhpBuiltinServer.php
@@ -69,6 +69,9 @@ class PhpBuiltinServer extends Extension
         if (isset($this->config['router'])) {
             $parameters .= ' -dcodecept.user_router="' . $this->config['router'] . '"';
         }
+        if (isset($this->config['alwaysUseRouter'])) {
+            $parameters .= ' -dcodecept.always_use_router="' . $this->config['alwaysUseRouter'] . '"';
+        }
         if (isset($this->config['directoryIndex'])) {
             $parameters .= ' -dcodecept.directory_index="' . $this->config['directoryIndex'] . '"';
         }

--- a/src/Codeception/Extension/Router.php
+++ b/src/Codeception/Extension/Router.php
@@ -31,7 +31,7 @@ class Router
             file_put_contents($accessLog, $logEntry, FILE_APPEND);
         }
 
-        if (file_exists($filePath) && is_file($filePath)) {
+        if (file_exists($filePath) && is_file($filePath) && !get_cfg_var('codecept.always_use_router')) {
             return false; // serve the requested resource as-is.
         } elseif ($userRouter) {
             return include $userRouter;


### PR DESCRIPTION
# The Problem

I needed to be able to have all server requests to the php built in server utilize my custom router.php file. This extension has a built in router which [sometimes sends requests straight to the servers document root and sometimes sends requests to the specified router.php](https://github.com/tiger-seo/PhpBuiltinServer/blob/master/src/Codeception/Extension/Router.php#L34-L37) file. 

# The Fix

I added an option to allow the developer to configure this extension to always send requests to the specified router file, instead of only sometimes. 

Works like this:

```
    config:
        Codeception\Extension\PhpBuiltinServer:
            hostname: localhost
            port: 9000
            documentRoot: src
            startDelay: 1
            router: my_router.php
            alwaysUseRouter: true
```