### PR TITLE
Renamed exception class names from codeception 1.x names to 2.x names

### DIFF
--- a/src/Codeception/Extension/PhpBuiltinServer.php
+++ b/src/Codeception/Extension/PhpBuiltinServer.php
@@ -6,9 +6,9 @@
 namespace Codeception\Extension;
 
 use Codeception\Configuration;
-use Codeception\Exception\ModuleConfig as ModuleConfigException;
+use Codeception\Exception\ModuleConfigException;
 use Codeception\Platform\Extension;
-use Codeception\Exception\Extension as ExtensionException;
+use Codeception\Exception\ExtensionException;
 
 class PhpBuiltinServer extends Extension
 {


### PR DESCRIPTION
Hi.
Current PhpBuiltinServer exception has it composer.json file set to require codeception ~2.0, but still is expecting the exceptions to be called as in codeception 1.x
I modified the `use` statements at top of the file to require the correct exception classes.