### PR TITLE
[BUG] Support query string for files

### DIFF
--- a/src/Codeception/Extension/Router.php
+++ b/src/Codeception/Extension/Router.php
@@ -14,7 +14,7 @@ class Router
         $directoryIndex = get_cfg_var('codecept.directory_index') ?: 'index.php';
 
         $documentRoot = $_SERVER['DOCUMENT_ROOT'];
-        $requestUri   = $_SERVER['REQUEST_URI'];
+        $requestUri   = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
         $filePath     = $documentRoot . '/' . ltrim($requestUri, '/');
 
         if ($accessLog) {


### PR DESCRIPTION
If file have query string (usually used for cache invalidation) - router doesn't serve the file, but forwarding it.