### PR TITLE
support CodeCeption settings error_level and memory_limit

### DIFF
--- a/src/Codeception/Extension/PhpBuiltinServer.php
+++ b/src/Codeception/Extension/PhpBuiltinServer.php
@@ -58,6 +58,8 @@ class PhpBuiltinServer extends Extension
      */
     private function getCommand()
     {
+        $codeCeptionSettings = Configuration::config()['settings'];
+
         $parameters = '';
         if (isset($this->config['router'])) {
             $parameters .= ' -dcodecept.user_router="' . $this->config['router'] . '"';
@@ -67,6 +69,12 @@ class PhpBuiltinServer extends Extension
         }
         if (isset($this->config['phpIni'])) {
             $parameters .= ' --php-ini "' . $this->config['phpIni'] . '"';
+        }
+        if (isset($codeCeptionSettings['error_level'])) {
+            $parameters .= ' --define error_level="' . $codeCeptionSettings['error_level'] . '"';
+        }
+        if (isset($codeCeptionSettings['memory_limit'])) {
+            $parameters .= ' --define memory_limit="' . $codeCeptionSettings['memory_limit'] . '"';
         }
         if ($this->isRemoteDebug()) {
             $parameters .= ' -dxdebug.remote_enable=1';


### PR DESCRIPTION
Adds support for CodeCeption settings `error_level` and `memory_limit`.

It does not work if `php_ini` extension configuration is set. This is due to how PHP `--php-ini` and `--define` arguments are working as far as I know. The `--php-ini` argument seems to overrule any `--define`.